### PR TITLE
[16.x] depend on libcxx-devel where necessary

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
   path: .
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not osx]
   script:
     echo "works!"
@@ -30,6 +30,11 @@ requirements:
     - libcxx {{ libcxx_major }}.*
     # pin this to a specific clang version on osx
     - clang-{{ cxx_compiler_version }}
+  {% if cxx_compiler_version|int < 16 and libcxx_major|int >= 16 %}
+    # older clang builds don't make use of libcxx-devel, c.f.
+    # https://github.com/conda-forge/clangdev-feedstock/pull/311
+    - libcxx-devel
+  {% endif %}
     - make
     - pip
     - libboost-devel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,9 @@
 {% set testing_generation = "0" %}
 {% set libcxx_major = 16 %}
 
+{% if libcxx_major is undefined %}
+{% set libcxx_major = 99 %}
+{% endif %}
 {% if cxx_compiler_version is undefined %}
 {% set cxx_compiler_version = libcxx_major %}
 {% endif %}


### PR DESCRIPTION
Backport #12